### PR TITLE
feat(web): switch from Inter to Geist font

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
 		"@tanstack/react-query": "^5.62.7",
 		"@trpc/client": "^11.0.0",
 		"@trpc/tanstack-react-query": "^11.0.0",
+		"geist": "^1.5.1",
 		"next": "^15.1.0",
 		"react": "^19.0.0",
 		"react-dom": "^19.0.0"

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,13 +1,7 @@
+import { GeistMono } from 'geist/font/mono'
+import { GeistSans } from 'geist/font/sans'
 import type { Metadata } from 'next'
-import { Inter } from 'next/font/google'
 import './globals.css'
-
-const inter = Inter({
-	subsets: ['latin'],
-	weight: ['400', '500', '600', '700'],
-	display: 'swap',
-	variable: '--font-inter',
-})
 
 export const metadata: Metadata = {
 	title: 'Headquarters',
@@ -16,7 +10,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
 	return (
-		<html lang="en" className={inter.variable}>
+		<html lang="en" className={`${GeistSans.variable} ${GeistMono.variable}`}>
 			<body className="font-sans antialiased">{children}</body>
 		</html>
 	)

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -5,7 +5,8 @@ const config: Config = {
 	theme: {
 		extend: {
 			fontFamily: {
-				sans: ['var(--font-inter)', 'system-ui', 'sans-serif'],
+				sans: ['var(--font-geist-sans)', 'system-ui', 'sans-serif'],
+				mono: ['var(--font-geist-mono)', 'ui-monospace', 'monospace'],
 			},
 		},
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       '@trpc/tanstack-react-query':
         specifier: ^11.0.0
         version: 11.0.0(@tanstack/react-query@5.90.12(react@19.2.1))(@trpc/client@11.0.0(@trpc/server@11.0.0(typescript@5.9.3))(typescript@5.9.3))(@trpc/server@11.0.0(typescript@5.9.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.9.3)
+      geist:
+        specifier: ^1.5.1
+        version: 1.5.1(next@15.5.7(@playwright/test@1.57.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
       next:
         specifier: ^15.1.0
         version: 15.5.7(@playwright/test@1.57.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -1574,6 +1577,11 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  geist@1.5.1:
+    resolution: {integrity: sha512-mAHZxIsL2o3ZITFaBVFBnwyDOw+zNLYum6A6nIjpzCGIO8QtC3V76XF2RnZTyLx1wlDTmMDy8jg3Ib52MIjGvQ==}
+    peerDependencies:
+      next: '>=13.2.0'
 
   gel@2.2.0:
     resolution: {integrity: sha512-q0ma7z2swmoamHQusey8ayo8+ilVdzDt4WTxSPzq/yRqvucWRfymRVMvNgmSC0XK7eNjjEZEcplxpgaNojKdmQ==}
@@ -3077,6 +3085,10 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  geist@1.5.1(next@15.5.7(@playwright/test@1.57.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)):
+    dependencies:
+      next: 15.5.7(@playwright/test@1.57.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
 
   gel@2.2.0:
     dependencies:


### PR DESCRIPTION
## Summary

- Replace Google Fonts Inter with Vercel's Geist font family
- Add Geist Sans for UI typography and Geist Mono for code/monospace
- Update Tailwind config to use new font CSS variables

## Why

Geist is Vercel's typeface designed for developers, offering better clarity and a modern feel. It integrates seamlessly with Next.js via the `geist` package.

## Test plan

- [x] TypeScript compiles without errors
- [x] Next.js build succeeds
- [ ] Visual check: fonts render correctly in browser

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)