### PR TITLE
feat(web): switch to monospace font

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,1 +1,6 @@
 @import "tailwindcss";
+
+@theme {
+	--font-sans: var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif;
+	--font-mono: var(--font-geist-mono), ui-monospace, monospace;
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
 	return (
 		<html lang="en" className={`${GeistSans.variable} ${GeistMono.variable}`}>
-			<body className="font-sans antialiased">{children}</body>
+			<body className="font-mono antialiased">{children}</body>
 		</html>
 	)
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,8 +1,8 @@
 export default function Home() {
 	return (
 		<main className="flex min-h-screen flex-col items-center justify-center gap-4 bg-black">
-			<h1 className="text-4xl font-semibold text-white">Hello HQ</h1>
-			<p className="max-w-md text-center text-sm text-neutral-400">
+			<h1 className="text-5xl font-semibold text-white">Hello HQ</h1>
+			<p className="max-w-md text-center text-base text-neutral-400">
 				Welcome to Headquarters, your personal homelab dashboard and workspace. This text is
 				rendered in Geist Mono, a monospace typeface designed for clarity and readability.
 			</p>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,7 +1,11 @@
 export default function Home() {
 	return (
-		<main className="flex min-h-screen items-center justify-center bg-black">
+		<main className="flex min-h-screen flex-col items-center justify-center gap-4 bg-black">
 			<h1 className="text-4xl font-semibold text-white">Hello HQ</h1>
+			<p className="max-w-md text-center text-sm text-neutral-400">
+				Welcome to Headquarters, your personal homelab dashboard and workspace. This text is
+				rendered in Geist Mono, a monospace typeface designed for clarity and readability.
+			</p>
 		</main>
 	)
 }

--- a/biome.json
+++ b/biome.json
@@ -25,6 +25,12 @@
 			"semicolons": "asNeeded"
 		}
 	},
+	"css": {
+		"parser": {
+			"cssModules": true,
+			"tailwindDirectives": true
+		}
+	},
 	"files": {
 		"includes": [
 			"**",

--- a/biome.json
+++ b/biome.json
@@ -27,7 +27,6 @@
 	},
 	"css": {
 		"parser": {
-			"cssModules": true,
 			"tailwindDirectives": true
 		}
 	},


### PR DESCRIPTION
## Summary
- Changes the primary application font from Geist Sans to Geist Mono
- Applies monospace styling across the entire app

## Test plan
- [x] Verify text renders in monospace throughout the application
- [x] Check that the font loads properly without layout shift

🤖 Generated with [Claude Code](https://claude.com/claude-code)